### PR TITLE
abstorage with a lazy init for  globally defined ORM paramenters

### DIFF
--- a/src/oidcmsg/storage/__init__.py
+++ b/src/oidcmsg/storage/__init__.py
@@ -1,4 +1,7 @@
+import logging
 from .utils import importer
+
+logger = logging.getLogger(__name__)
 
 
 class AbstractStorage(object):
@@ -11,7 +14,12 @@ class AbstractStorage(object):
         if isinstance(conf_dict['handler'], str):
             _handler = importer(conf_dict['handler'])
             _args = {k: v for k, v in conf_dict.items() if k != 'handler'}
-            self.storage = _handler(_args)
+            try:
+                self.storage = _handler(_args)
+            except TypeError as e:
+                # needed for globally configured ORM models
+                logger.debug('Abstorage {}: {}'.format(_handler, e))
+                self.storage = _handler()
         else:
             self.storage = conf_dict['handler'](conf_dict)
 


### PR DESCRIPTION
In Django we define Database Schema as class and they don't need to be initialized by ABStorage with a configuration dict.
Example configuration:

````
    db_conf:
      abstract_storage_cls: oidcmsg.storage.extension.LabeledAbstractStorage
      client:
        handler: oidc_op.db_interfaces.OidcClientDatabase
````

see https://github.com/peppelinux/django-oidc-op