### PR TITLE
Don't deepcopy config

### DIFF
--- a/src/oidcmsg/context.py
+++ b/src/oidcmsg/context.py
@@ -16,7 +16,7 @@ def add_issuer(conf, issuer):
         if key == 'abstract_storage_cls':
             res[key] = val
         else:
-            _val = copy.deepcopy(val)
+            _val = copy.copy(val)
             _val['issuer'] = quote_plus(issuer)
             res[key] = _val
     return res


### PR DESCRIPTION
Shallow copy the storage configuration, not all parameters can be
copied. Since this is a storage class it should be common that it is
passed some thread local variables that don't allow copying.

It should be up to the caller to make sure that the dict is not reused