### PR TITLE
Get AbstractStorageSQLAlchemy working.

### DIFF
--- a/src/oidcmsg/storage/absqlalchemy.py
+++ b/src/oidcmsg/storage/absqlalchemy.py
@@ -2,7 +2,7 @@ import datetime
 import json
 
 import sqlalchemy as alchemy_db
-from sqlalchemy.orm import sessionmaker, scoped_session
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 PlainDict = dict
 

--- a/src/oidcmsg/storage/absqlalchemy.py
+++ b/src/oidcmsg/storage/absqlalchemy.py
@@ -4,14 +4,12 @@ import json
 import sqlalchemy as alchemy_db
 from sqlalchemy.orm import sessionmaker
 
-from oidcmsg.storage.db_setup import Base
-
+PlainDict = dict
 
 class AbstractStorageSQLAlchemy:
     def __init__(self, conf_dict):
         self.engine = alchemy_db.create_engine(conf_dict['url'])
         self.connection = self.engine.connect()
-        Base.metadata.create_all(self.engine)
         self.metadata = alchemy_db.MetaData()
         self.table = alchemy_db.Table(conf_dict['params']['table'],
                                       self.metadata, autoload=True,
@@ -20,59 +18,37 @@ class AbstractStorageSQLAlchemy:
         self.session = Session()
 
     def get(self, k):
-        entries = self.session.query(self.table).filter_by(owner=k).all()
-        result = self._data_from_db(entries)
-        return result
-
-    def _data_from_db(self, entries):
-        result = []
-        for entry in entries:
-            try:
-                data = json.loads(entry.data)
-                if isinstance(data, list):
-                    result.extend(data)
-                else:
-                    result.append(data)
-            except:
-                result.append(entry.data)
-        return result
-
-    def _data_to_db(self, v):
-        if isinstance(v, dict) or isinstance(v, list):
-            value = json.dumps(v)
-        else:
-            value = v
-        return value
+        entry = self.session.query(self.table).filter_by(owner=k).first()
+        if entry is None:
+            return None
+        return entry.data
 
     def set(self, k, v):
-        value = self._data_to_db(v)
+        self.delete(k)
         ins = self.table.insert().values(owner=k,
-                                         data=value)
+                                         data=v)
         self.session.execute(ins)
         self.session.commit()
         return 1
 
-    def update(self, k, v, col_match='owner', col_value='data'):
+    def update(self, k, v):
         """
             k = value_to_match
             v = value_to_be_substituted
         """
-        value = self._data_to_db(v)
-        table_column = getattr(self.table.c, col_match)
         upquery = self.table.update(). \
-            where(table_column == k). \
-            values(**{col_value: value})
+            where(self.table.c.owner == k). \
+            values(**{'data': v})
         self.session.execute(upquery)
         self.session.commit()
         return 1
 
-    def delete(self, v, k='owner'):
+    def delete(self, v):
         """
         return the count of deleted objects
         """
-        table_column = getattr(self.table.c, k)
-        delquery = self.table.delete().where(table_column == v)
-        n_entries = self.session.query(self.table).filter(table_column == v).count()
+        delquery = self.table.delete().where(self.table.c.owner == v)
+        n_entries = self.session.query(self.table).filter(self.table.c.owner == v).count()
         self.session.execute(delquery)
         return n_entries
 
@@ -108,3 +84,6 @@ class AbstractStorageSQLAlchemy:
         except:
             self.session.rollback()
             self.session.flush()
+
+    def __setitem__(self, k, v):
+        return self.set(k, v)


### PR DESCRIPTION
This is a patch that gets AbstractStorageSQLAlchemy working. Note, it probably has some issues that need resolving another way but that is beyond my pay grade because I don't know this library well enough. But I think this is a pretty good cleanup and suits my needs.

Some of the (opinionated) changes:

1) Got rid of the behavior where it automatically always creates the table it was referring to via a call to create *all tables*. That should be under the control of the surrounding application not a library.

2) Got rid of the import of the sample Table as it was polluting the surrounding application's metadata. This should not be done by a library and is better managed by the application. Note, there could be more cleanup here (like optionally passing in an existing engine instead of creating one) but I wasn't sure how to arrange that.

3) General cleanup and simplification. There were clearly assumptions changed with how the calling code uses a Storage and this code needed fixes for that.

4) Introduced a hack that resolved an issue using this storage back end. When enabled, it interfered with the key jar storage mechanism. The default used for that changes when a db_conf without a default is supplied and it breaks. So, the PlainDict at the top of this PR is a hack around it. See the configuration below which is working for my OP:

```
            "db_conf": {
                "state": {
                    "handler": "oidcmsg.storage.absqlalchemy.AbstractStorageSQLAlchemy",
                    "url": "postgresql:///application",
                    "params": {
                        "table": "oidc_storage"
                    }
                },
                "default": {
                    "handler": "oidcmsg.storage.absqlalchemy.PlainDict"
                }
            }
```