### PR TITLE
Endsession message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ test:
 .PHONY: test
 
 isort:
-	@pipenv run isort --recursive $(OICDIR) $(TESTDIR)
+	@pipenv run isort $(OICDIR) $(TESTDIR)
 
 check-isort:
-	@pipenv run isort --recursive --diff --check-only $(OICDIR) $(TESTDIR)
+	@pipenv run isort --diff --check-only $(OICDIR) $(TESTDIR)
 .PHONY: isort check-isort
 
 check-pylama:

--- a/src/oidcmsg/__init__.py
+++ b/src/oidcmsg/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'Roland Hedberg'
-__version__ = '1.1.2'
+__version__ = '1.1.3'
 
 VERIFIED_CLAIM_PREFIX = '__verified'
 

--- a/src/oidcmsg/oidc/session.py
+++ b/src/oidcmsg/oidc/session.py
@@ -6,6 +6,7 @@ from oidcmsg.time_util import utc_time_sans_frac
 
 from ..exception import MessageException
 from ..exception import NotForMe
+from ..message import OPTIONAL_LIST_OF_SP_SEP_STRINGS
 from ..message import REQUIRED_LIST_OF_STRINGS
 from ..message import SINGLE_OPTIONAL_STRING
 from ..message import SINGLE_REQUIRED_INT
@@ -50,7 +51,8 @@ class EndSessionRequest(Message):
     c_param = {
         "id_token_hint": SINGLE_OPTIONAL_IDTOKEN,
         "post_logout_redirect_uri": SINGLE_OPTIONAL_STRING,
-        "state": SINGLE_OPTIONAL_STRING
+        "state": SINGLE_OPTIONAL_STRING,
+        "ui_locales": OPTIONAL_LIST_OF_SP_SEP_STRINGS
     }
 
     def verify(self, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands = sphinx-build -b html doc/ doc/_build/html -W
 ignore_errors = True
 extras = quality
 commands =
-    isort --recursive --diff --check-only src/ tests/
+    isort --diff --check-only src/ tests/
     pylama src/ tests/
 
 [pep8]


### PR DESCRIPTION
According to https://openid.net/specs/openid-connect-rpinitiated-1_0.html the log out message can contain the ui_locales parameter. Was missing in the code.