### PR TITLE
Fix ProviderConfigurationResponse verification

### DIFF
--- a/src/oidcmsg/oidc/__init__.py
+++ b/src/oidcmsg/oidc/__init__.py
@@ -928,6 +928,12 @@ class ProviderConfigurationResponse(ResponseMessage):
         if "RS256" not in self["id_token_signing_alg_values_supported"]:
             raise ValueError('RS256 missing from id_token_signing_alg_values_supported')
 
+        if "none" in self["token_endpoint_auth_signing_alg_values_supported"]:
+            raise ValueError(
+                "The value none must not be used for "
+                "token_endpoint_auth_signing_alg_values_supported"
+            )
+
         if not parts.query and not parts.fragment:
             pass
         else:


### PR DESCRIPTION
According to https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
the value "none" must not be used for `token_endpoint_auth_signing_alg_values_supported`

Should be merged along with https://github.com/IdentityPython/oidcendpoint/pull/99, in order not to break oidcendpoint