### PR TITLE
feat: release-drafter github action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,54 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+-
+  title: 'Features'
+  labels:
+  - 'enhancement'
+  - 'feat'
+  - 'feature'
+-
+  title: 'Bug Fixes'
+  labels:
+  - 'bug'
+  - 'bugfix'
+  - 'fix'
+-
+  title: 'Maintenance'
+  labels:
+  - 'chore'
+  - 'style'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels: ['major']
+  minor:
+    labels: ['minor']
+  patch:
+    labels: ['patch']
+  default: patch
+exclude-labels: ['skip']
+autolabeler:
+-
+  label: 'bug'
+  branch:
+  - '/bug\/.+/'
+  - '/bugfix\/.+/'
+  - '/fix\/.+/'
+-
+  label: 'enhancement'
+  branch:
+  - '/dependabot\/.+/'
+  - '/enhancement\/.+/'
+  - '/feat\/.+/'
+  - '/feature\/.+/'
+-
+  label: 'chore'
+  branch:
+  - '/chore\/.+/'
+  - '/style\/.+/'
+template: |
+  ## Release notes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,17 @@
+name: Release drafter
+
+on:
+  push:
+    branches: [main, master, dev]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update_release_draft:
+    name: Update draft release
+    runs-on: ubuntu-latest
+    steps:
+    -
+      uses: release-drafter/release-drafter@v5
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
this PR introduce release-drafter github action
It just have a github token to drive the release draft each time a PR will be merged in master branch (or dev, or main ... that's not here)