### PR TITLE
Fix calculation of epoch that is not taking into account the timezone

### DIFF
--- a/src/oidcmsg/time_util.py
+++ b/src/oidcmsg/time_util.py
@@ -348,7 +348,8 @@ def later_than(after, before):
 
 
 def utc_time_sans_frac():
-    return int((datetime.utcnow() - datetime(1970, 1, 1)).total_seconds())
+    now_timestampt = int(datetime.utcnow().timestamp())
+    return now_timestampt
 
 
 def time_sans_frac():
@@ -372,4 +373,5 @@ def epoch_in_a_while(
     """
 
     dt = time_in_a_while(days, seconds, microseconds, milliseconds, minutes, hours, weeks)
-    return int((dt - datetime(1970, 1, 1)).total_seconds())
+    dt_timestamp = int(dt.timestamp())
+    return dt_timestamp


### PR DESCRIPTION
The problem is that `datetime(1970, 1, 1)` does not include a timezone component and it is assumed to be a local date.

```py
>>> import datetime
>>> bad = datetime.datetime(1970, 1, 1)
>>> bad
datetime.datetime(1970, 1, 1, 0, 0)
>>> bad.astimezone(datetime.timezone.utc)
datetime.datetime(1969, 12, 31, 22, 0, tzinfo=datetime.timezone.utc)
```

The reason for this is because my localtime is not UTC, but "Europe/Athens".
If my timezone was UTC, then this would look as expected:

```py
$ cat /etc/timezone 
UTC

$ python3
>>> import datetime
>>> happens_to_be_correct = datetime.datetime(1970, 1, 1)
>>> happens_to_be_correct
datetime.datetime(1970, 1, 1, 0, 0)
>>> happens_to_be_correct.astimezone(datetime.timezone.utc)
datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
```

---

The right thing to do is to have an explicit timezone component on the date object

```py
>>> better = datetime.datetime(1970, 1, 1, hour=0, minute=0, second=0, microsecond=0, tzinfo=datetime.timezone.utc)
>>> better
datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
>>> better.astimezone(datetime.timezone.utc)
datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
```

Calculations against that object would yield correct results.

---

However, it is not needed to do such a calculation "by hand", as the standard library provides the tools to convert a `datetime` object to a timestamp

```py
>>> import datetime
>>> better = datetime.datetime(1970, 1, 1, hour=0, minute=0, second=0, microsecond=0, tzinfo=datetime.timezone.utc)
>>> better.timestamp()
0.0
```

```py
>>> dt = datetime.datetime.utcnow()
>>> dt
datetime.datetime(2021, 10, 27, 19, 5, 50, 776761)
>>> dt.timestamp()
1635350750.776761
```

So, instead of calculating the timestamp by creating a delta between two dates (which must be on the same timezone) and converting the result to seconds, we can just get the timestamp by calling `.timestamp()` on the datetime object. The timestamp will be relative to the datetime object timezone, which we must ensure is always on UTC.