### PR TITLE
Remove support for Python 3.6.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,10 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Libraries :: Python Modules"],
     install_requires=[
         "cryptojwt==1.6.1",

--- a/src/oidcmsg/__init__.py
+++ b/src/oidcmsg/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Roland Hedberg"
-__version__ = "1.5.4"
+__version__ = "1.6.0"
 
 import os
 from typing import Dict

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38},docs,quality
+envlist = py{37,38,39,310},docs,quality
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*


### PR DESCRIPTION
Supported set: 3.7, 3.8, 3.9. 3.10 .